### PR TITLE
feat: add support for arbitrary server port

### DIFF
--- a/web_login.go
+++ b/web_login.go
@@ -20,7 +20,7 @@ import (
 )
 
 func WebLogin(server string, username string, password string) string {
-	server = "https://" + server + ":443"
+	server = "https://" + server
 
 	c := &http.Client{
 		Transport: &http.Transport{
@@ -161,7 +161,7 @@ func WebLogin(server string, username string, password string) string {
 }
 
 func ECAgentToken(server string, twfId string) string {
-	dialConn, err := net.Dial("tcp", server+":443")
+	dialConn, err := net.Dial("tcp", server)
 	defer dialConn.Close()
 	conn := utls.UClient(dialConn, &utls.Config{InsecureSkipVerify: true}, utls.HelloGolang)
 	defer conn.Close()


### PR DESCRIPTION
In some situation, the easyconnect server is not deployed with port 443 but other ports. To fix it we can add a field of port which defaults to 443.