### PR TITLE
Prevent client from being garbage collected

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"runtime"
 )
 
 func main() {
@@ -51,4 +52,6 @@ func main() {
 	log.Printf("Login success, your IP: %d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3])
 
 	client.ServeSocks5(socksBind, debugDump)
+
+	runtime.KeepAlive(client)
 }


### PR DESCRIPTION
Fixed #10
var "client" will be garbage collected when the traffic pressure is high, 
which leads to the disconnection of "queryConn" and breaks the link.