### PR TITLE
[bugfix] use thread-local statistic vars

### DIFF
--- a/core/protocol.go
+++ b/core/protocol.go
@@ -168,7 +168,7 @@ func BlockTXStream(server string, token *[48]byte, ipRev *[4]byte, ep *EasyConne
 	errCh := make(chan error)
 
 	ep.OnRecv = func(buf []byte) {
-		n, err = conn.Write(buf)
+		var n, err = conn.Write(buf)
 		if err != nil {
 			errCh <- err
 			return


### PR DESCRIPTION
Fixed #19 
variable n and err are caught from outer scope, this leads to data race in multithreaded environments